### PR TITLE
Fix issue #22: Setting api_config.echo to False

### DIFF
--- a/scalingup/utils/openai_api.py
+++ b/scalingup/utils/openai_api.py
@@ -391,6 +391,7 @@ class GPT3Wrapper:
                     logging.warning(f"OpenAI API got err {e}")
                     logging.warning(f"Retrying after {GPT3Wrapper.TIMEOUT}s.")
                     time.sleep(GPT3Wrapper.TIMEOUT)
+        api_config.echo = False
         m = hashlib.sha256()
         m.update(prompt.encode("utf-8"))
         m.update(str(api_config).encode("utf-8"))


### PR DESCRIPTION
The core problem of issue #22 is `api_config.echo` is set to `True` in `scalingup_fork/scalingup/utils/openai_api.py` between commit 3d2f43c and c45ba99. Therefore, setting it back to `False` solves the problem.